### PR TITLE
fix the sign on even wavelet decomposition filter coefficients

### DIFF
--- a/src/jwave/transforms/wavelets/Wavelet.java
+++ b/src/jwave/transforms/wavelets/Wavelet.java
@@ -109,9 +109,9 @@ public abstract class Wavelet {
     _waveletDeCom = new double[ _motherWavelength ];
     for( int i = 0; i < _motherWavelength; i++ )
       if( i % 2 == 0 )
-        _waveletDeCom[ i ] = _scalingDeCom[ ( _motherWavelength - 1 ) - i ];
-      else
         _waveletDeCom[ i ] = -_scalingDeCom[ ( _motherWavelength - 1 ) - i ];
+      else
+        _waveletDeCom[ i ] = _scalingDeCom[ ( _motherWavelength - 1 ) - i ];
     // Copy to reconstruction filters due to orthogonality (orthonormality)!
     _scalingReCon = new double[ _motherWavelength ];
     _waveletReCon = new double[ _motherWavelength ];


### PR DESCRIPTION
@cscheiblich Hi! I found a bug in high pass filter coefficients sign.

The sign of first coefficient should be negative if as mentioned in the documentation you are using pywavelets filter coefficients provided here - http://wavelets.pybytes.com/wavelet/db10/

 opened an issue here regarding the same (feel free to close it) - https://github.com/cscheiblich/JWave/issues/19